### PR TITLE
Add rate limit reason to exception

### DIFF
--- a/lib/xeroizer/http.rb
+++ b/lib/xeroizer/http.rb
@@ -172,7 +172,9 @@ module Xeroizer
         case problem
           when "token_expired"                then raise OAuth::TokenExpired.new(description)
           when "token_rejected"               then raise OAuth::TokenInvalid.new(description)
-          when "rate limit exceeded"          then raise OAuth::RateLimitExceeded.new(description)
+          when "rate limit exceeded"
+            error_type = response["x-rate-limit-problem"]
+            raise OAuth::RateLimitExceeded.new("#{description}, #{error_type}")
           when "consumer_key_unknown"         then raise OAuth::ConsumerKeyUnknown.new(description)
           when "nonce_used"                   then raise OAuth::NonceUsed.new(description)
           when "organisation offline"         then raise OAuth::OrganisationOffline.new(description)


### PR DESCRIPTION
Xero provides a limit problem header field to explain what sort of rate limit has been hit when using the Xero API (either 60 a second or 5000 a day).

Added some more detail to the rate limit error that gets thrown when the rate limit is hit.

https://developer.xero.com/documentation/auth-and-limits/xero-api-limits