### PR TITLE
Remove list_contains_summary_only tag

### DIFF
--- a/lib/xeroizer/models/bank_transaction.rb
+++ b/lib/xeroizer/models/bank_transaction.rb
@@ -28,7 +28,6 @@ module Xeroizer
       end
 
       set_primary_key :bank_transaction_id
-      list_contains_summary_only true
 
       string :type
       date :date


### PR DESCRIPTION
Paginated bank transactions from the Xero API contain less information than if you
were to just get a single transaction using it's id.

When accessing the bank_account and contact information of paginated bank
transactions, the gem then goes to the server again to get the full
details of the bank transaction and related objects.

The information we get from the paginated bank transaction data is
enough for us to use in our importers. By removing the
`list_contains_summary_only` attribute in the model this will stop the
gem from going to revtrieve the complete record when the bank_account
or contact is accessed.

This should reduce our number of requests by a decent amount (by how
many bank transactions are retrieved) and reduce the time taken to run
the import.