### PR TITLE
Update forked changes

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -60,7 +60,6 @@ module Xeroizer
       decimal       :sub_total, :calculated => true
       decimal       :total_tax, :calculated => true
       decimal       :total, :calculated => true
-      decimal       :remaining_credit
       datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
       string        :currency_code
       decimal       :currency_rate

--- a/lib/xeroizer/models/purchase_order.rb
+++ b/lib/xeroizer/models/purchase_order.rb
@@ -2,20 +2,20 @@ require "xeroizer/models/attachment"
 
 module Xeroizer
   module Record
-
+    
     class PurchaseOrderModel < BaseModel
-
+        
       set_permissions :read, :write, :update
 
       include AttachmentModel::Extensions
     end
-
+    
     class PurchaseOrder < Base
       include Attachment::Extensions
-
+      
       set_primary_key :purchase_order_id
       set_possible_primary_keys :purchase_order_id
-
+      
       guid    :purchase_order_id
       string  :purchase_order_number
       string  :date_string
@@ -26,24 +26,24 @@ module Xeroizer
       string  :attention_to
       string  :telephone
       string  :delivery_instructions
-      boolean :has_errors
-      boolean :is_discounted
+      boolean :has_errors 
+      boolean :is_discounted 
       string  :reference
       string  :type
       decimal  :currency_rate
       string  :currency_code
-      guid    :branding_theme_id
-      string  :status
+      guid    :branding_theme_id 
+      string  :status 
       string  :line_amount_types
       decimal  :sub_total
       decimal  :total_tax
-      decimal  :total
+      decimal  :total 
       datetime_utc :updated_date_utc, :api_name => 'UpdatedDateUTC'
       boolean :has_attachments
 
       has_many     :line_items
-      belongs_to :contact, :model_name => 'Contact'
+      belongs_to :contact, :model_name => 'Contact'      
     end
-
+    
   end
 end


### PR DESCRIPTION
Quick PR to remove some of the diff between our fork and the original branch.

`:remaining_credit` attribute was duplicated in the credit note model. I am assuming it was added later to the gem.

The whitespace was removed (probably by default editor settings). I know it has no impact but would rather the file didn't show in the diff.